### PR TITLE
feat(badge): implement badge count API, silent push handling, and iotumBadge compatibility shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebasex",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cordova plugin for Google Firebase",
   "types": "./types/index.d.ts",
   "author": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-firebasex" version="1.0.2"
+<plugin id="cordova-plugin-firebasex" version="1.0.3"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,10 @@
 	<preference name="GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA" default="true" />
 	<preference name="GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS" default="true" />
 
+	<js-module name="IotumBadgeCompatibility" src="www/iotumBadge.js">
+		<clobbers target="cordova.plugins.iotumBadge" />
+	</js-module>
+
 	<platform name="android">
 		<preference name="ANDROID_ICON_ACCENT" default="#FF00FFFF" />
 		<preference name="ANDROID_FIREBASE_PERFORMANCE_MONITORING" default="false" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -166,6 +166,8 @@
 		<source-file src="src/ios/FirebasePluginMessageReceiver.m" />
 		<header-file src="src/ios/FirebasePluginMessageReceiverManager.h" />
 		<source-file src="src/ios/FirebasePluginMessageReceiverManager.m" />
+		<header-file src="src/ios/FirebaseBadgeMessageReceiver.h" />
+		<source-file src="src/ios/FirebaseBadgeMessageReceiver.m" />
 
 		<framework src="AuthenticationServices.framework" />
 

--- a/src/android/CustomFCMReceiverPlugin.java
+++ b/src/android/CustomFCMReceiverPlugin.java
@@ -52,7 +52,20 @@ public class CustomFCMReceiverPlugin {
         JSONObject payload = new JSONObject(payloadString);
 
         String type = payload.optString("type");
-        if (type.equals("incoming_phone_call") || type.equals("incoming_video_call")) {
+        if (type.equals("badge_update")) {
+            if (!payload.has("total")) {
+                return false;
+            }
+
+            int total = payload.optInt("total", -1);
+            if (total < 0) {
+                return false;
+            }
+
+            FirebasePlugin.persistBadgeNumber(this.applicationContext, total);
+            Log.d(TAG, "Persisted badge_update total=" + total);
+            isHandled = true;
+        } else if (type.equals("incoming_phone_call") || type.equals("incoming_video_call")) {
             isHandled = true;
 
             Intent intent = new Intent("INCOMING_CALL_INVITE");

--- a/src/android/CustomFCMReceiverPlugin.java
+++ b/src/android/CustomFCMReceiverPlugin.java
@@ -53,18 +53,12 @@ public class CustomFCMReceiverPlugin {
 
         String type = payload.optString("type");
         if (type.equals("badge_update")) {
-            if (!payload.has("total")) {
-                return false;
-            }
-
-            int total = payload.optInt("total", -1);
-            if (total < 0) {
-                return false;
-            }
-
-            FirebasePlugin.persistBadgeNumber(this.applicationContext, total);
-            Log.d(TAG, "Persisted badge_update total=" + total);
             isHandled = true;
+            int total = payload.optInt("total", -1);
+            if (total >= 0) {
+                FirebasePlugin.persistBadgeNumber(this.applicationContext, total);
+                Log.d(TAG, "Persisted badge_update total=" + total);
+            }
         } else if (type.equals("incoming_phone_call") || type.equals("incoming_video_call")) {
             isHandled = true;
 

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -154,6 +154,8 @@ public class FirebasePlugin extends CordovaPlugin {
     protected static final String TAG = "FirebasePlugin";
     protected static final String JS_GLOBAL_NAMESPACE = "FirebasePlugin.";
     protected static final String KEY = "badge";
+    protected static final String BADGE_PREFS_NAME = "iotum_badge";
+    protected static final String BADGE_KEY = "badge_count";
     protected static final int GOOGLE_SIGN_IN = 0x1;
     protected static final String SETTINGS_NAME = "settings";
     private static final String ANALYTICS_COLLECTION_ENABLED = "firebase_analytics_collection_enabled";
@@ -543,10 +545,14 @@ public class FirebasePlugin extends CordovaPlugin {
                     break;
                 case "grantCriticalPermission":
                 case "hasCriticalPermission":
-                case "setBadgeNumber":
-                case "getBadgeNumber":
                     // Stubs for other platform methods
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+                    break;
+                case "setBadgeNumber":
+                    this.setBadgeNumber(args, callbackContext);
+                    break;
+                case "getBadgeNumber":
+                    this.getBadgeNumber(callbackContext);
                     break;
                 case "deleteInstallationId":
                     this.deleteInstallationId(args, callbackContext);
@@ -802,6 +808,56 @@ public class FirebasePlugin extends CordovaPlugin {
                 }
             }
         });
+    }
+
+    private void setBadgeNumber(final JSONArray args, final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    int number = Math.max(0, args.optInt(0, 0));
+                    persistBadgeNumber(applicationContext, number);
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, number));
+                } catch (Exception e) {
+                    handleExceptionWithContext(e, callbackContext);
+                }
+            }
+        });
+    }
+
+    private void getBadgeNumber(final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    int number = getPersistedBadgeNumber(applicationContext);
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, number));
+                } catch (Exception e) {
+                    handleExceptionWithContext(e, callbackContext);
+                }
+            }
+        });
+    }
+
+    static void persistBadgeNumber(Context context, int number) {
+        if (context == null) {
+            Log.w(TAG, "Cannot persist badge number: context is null");
+            return;
+        }
+
+        int normalized = Math.max(0, number);
+        SharedPreferences settings = context.getSharedPreferences(BADGE_PREFS_NAME, MODE_PRIVATE);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putInt(BADGE_KEY, normalized);
+        editor.apply();
+    }
+
+    static int getPersistedBadgeNumber(Context context) {
+        if (context == null) {
+            Log.w(TAG, "Cannot read badge number: context is null");
+            return 0;
+        }
+
+        SharedPreferences settings = context.getSharedPreferences(BADGE_PREFS_NAME, MODE_PRIVATE);
+        return settings.getInt(BADGE_KEY, 0);
     }
 
     private void hasPermission(final CallbackContext callbackContext) {

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -1,6 +1,8 @@
 #import "AppDelegate+FirebasePlugin.h"
 #import "FirebasePlugin.h"
 #import "FirebaseWrapper.h"
+#import "FirebaseBadgeMessageReceiver.h"
+#import "FirebasePluginMessageReceiverManager.h"
 #import <objc/runtime.h>
 
 
@@ -142,6 +144,10 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
 
         self.applicationInBackground = @(YES);
         
+        // Register badge receiver early so it handles silent pushes even during cold start,
+        // before the Cordova plugin (and FirebasePlugin.firebasePlugin) are initialized.
+        [[FirebaseBadgeMessageReceiver alloc] init];
+        
     }@catch (NSException *exception) {
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
     }
@@ -236,7 +242,12 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
             [self processMessageForForegroundNotification:mutableUserInfo];
         }
         if([self.applicationInBackground isEqual:[NSNumber numberWithBool:YES]] || !isContentAvailable){
-            [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+            if(FirebasePlugin.firebasePlugin != nil){
+                [FirebasePlugin.firebasePlugin sendNotification:mutableUserInfo];
+            }else{
+                // Plugin not yet initialized (cold start): route directly to registered receivers.
+                [FirebasePluginMessageReceiverManager sendNotification:mutableUserInfo];
+            }
         }
     }@catch (NSException *exception) {
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];

--- a/src/ios/FirebaseBadgeMessageReceiver.h
+++ b/src/ios/FirebaseBadgeMessageReceiver.h
@@ -1,0 +1,4 @@
+#import "FirebasePluginMessageReceiver.h"
+
+@interface FirebaseBadgeMessageReceiver : FirebasePluginMessageReceiver
+@end

--- a/src/ios/FirebaseBadgeMessageReceiver.m
+++ b/src/ios/FirebaseBadgeMessageReceiver.m
@@ -1,0 +1,42 @@
+#import "FirebaseBadgeMessageReceiver.h"
+#import <UIKit/UIKit.h>
+
+@implementation FirebaseBadgeMessageReceiver
+
+- (bool)sendNotification:(NSDictionary *)userInfo {
+    NSString *payloadString = userInfo[@"payload"];
+    if (!payloadString || ![payloadString isKindOfClass:[NSString class]]) {
+        return false;
+    }
+
+    NSData *jsonData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
+    if (jsonData == nil) {
+        return false;
+    }
+
+    NSError *error = nil;
+    id parsed = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+    if (error || !parsed || ![parsed isKindOfClass:[NSDictionary class]]) {
+        return false;
+    }
+
+    NSDictionary *payload = (NSDictionary *)parsed;
+    NSString *type = payload[@"type"];
+    if (![@"badge_update" isEqualToString:type]) {
+        return false;
+    }
+
+    id totalValue = payload[@"total"];
+    if (!totalValue || ![totalValue respondsToSelector:@selector(intValue)]) {
+        return false;
+    }
+
+    int total = [totalValue intValue];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:MAX(0, total)];
+    });
+
+    return true;
+}
+
+@end

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -1,5 +1,6 @@
 #import "FirebasePlugin.h"
 #import "FirebasePluginMessageReceiverManager.h"
+#import "FirebaseBadgeMessageReceiver.h"
 #import "AppDelegate+FirebasePlugin.h"
 #import <Cordova/CDV.h>
 #import "AppDelegate.h"
@@ -14,49 +15,6 @@
 @import UserNotifications;
 @import CommonCrypto;
 @import AuthenticationServices;
-
-@interface FirebaseBadgeMessageReceiver : FirebasePluginMessageReceiver
-@end
-
-@implementation FirebaseBadgeMessageReceiver
-
-- (bool)sendNotification:(NSDictionary *)userInfo {
-    NSString *payloadString = userInfo[@"payload"];
-    if (!payloadString || ![payloadString isKindOfClass:[NSString class]]) {
-        return false;
-    }
-
-    NSData *jsonData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
-    if (jsonData == nil) {
-        return false;
-    }
-
-    NSError *error = nil;
-    id parsed = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-    if (error || !parsed || ![parsed isKindOfClass:[NSDictionary class]]) {
-        return false;
-    }
-
-    NSDictionary *payload = (NSDictionary *)parsed;
-    NSString *type = payload[@"type"];
-    if (![@"badge_update" isEqualToString:type]) {
-        return false;
-    }
-
-    id totalValue = payload[@"total"];
-    if (!totalValue || ![totalValue respondsToSelector:@selector(intValue)]) {
-        return false;
-    }
-
-    int total = [totalValue intValue];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:MAX(0, total)];
-    });
-
-    return true;
-}
-
-@end
 
 @implementation FirebasePlugin
 {

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -17,9 +17,6 @@
 @import AuthenticationServices;
 
 @implementation FirebasePlugin
-{
-    FirebaseBadgeMessageReceiver* _badgeMessageReceiver;
-}
 
 @synthesize openSettingsCallbackId;
 @synthesize notificationCallbackId;
@@ -81,7 +78,7 @@ static NSMutableArray* pendingGlobalJS = nil;
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
     firebasePlugin = self;
-    _badgeMessageReceiver = [[FirebaseBadgeMessageReceiver alloc] init];
+    [[FirebaseBadgeMessageReceiver alloc] init];
 
     @try {
         preferences = [NSUserDefaults standardUserDefaults];

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -15,7 +15,53 @@
 @import CommonCrypto;
 @import AuthenticationServices;
 
+@interface FirebaseBadgeMessageReceiver : FirebasePluginMessageReceiver
+@end
+
+@implementation FirebaseBadgeMessageReceiver
+
+- (bool)sendNotification:(NSDictionary *)userInfo {
+    NSString *payloadString = userInfo[@"payload"];
+    if (!payloadString || ![payloadString isKindOfClass:[NSString class]]) {
+        return false;
+    }
+
+    NSData *jsonData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
+    if (jsonData == nil) {
+        return false;
+    }
+
+    NSError *error = nil;
+    id parsed = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+    if (error || !parsed || ![parsed isKindOfClass:[NSDictionary class]]) {
+        return false;
+    }
+
+    NSDictionary *payload = (NSDictionary *)parsed;
+    NSString *type = payload[@"type"];
+    if (![@"badge_update" isEqualToString:type]) {
+        return false;
+    }
+
+    id totalValue = payload[@"total"];
+    if (!totalValue || ![totalValue respondsToSelector:@selector(intValue)]) {
+        return false;
+    }
+
+    int total = [totalValue intValue];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:MAX(0, total)];
+    });
+
+    return true;
+}
+
+@end
+
 @implementation FirebasePlugin
+{
+    FirebaseBadgeMessageReceiver* _badgeMessageReceiver;
+}
 
 @synthesize openSettingsCallbackId;
 @synthesize notificationCallbackId;
@@ -77,6 +123,7 @@ static NSMutableArray* pendingGlobalJS = nil;
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
     firebasePlugin = self;
+    _badgeMessageReceiver = [[FirebaseBadgeMessageReceiver alloc] init];
 
     @try {
         preferences = [NSUserDefaults standardUserDefaults];

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -1,6 +1,5 @@
 #import "FirebasePlugin.h"
 #import "FirebasePluginMessageReceiverManager.h"
-#import "FirebaseBadgeMessageReceiver.h"
 #import "AppDelegate+FirebasePlugin.h"
 #import <Cordova/CDV.h>
 #import "AppDelegate.h"
@@ -78,7 +77,6 @@ static NSMutableArray* pendingGlobalJS = nil;
 - (void)pluginInitialize {
     NSLog(@"Starting Firebase plugin");
     firebasePlugin = self;
-    [[FirebaseBadgeMessageReceiver alloc] init];
 
     @try {
         preferences = [NSUserDefaults standardUserDefaults];

--- a/www/iotumBadge.js
+++ b/www/iotumBadge.js
@@ -14,5 +14,5 @@ exports.clear = function (callback, errorCallback) {
 };
 
 exports.get = function (callback, errorCallback) {
-    exec(callback, errorCallback || null, 'FirebasePlugin', 'getBadgeNumber', []);
+    exec(callback || null, errorCallback || null, 'FirebasePlugin', 'getBadgeNumber', []);
 };

--- a/www/iotumBadge.js
+++ b/www/iotumBadge.js
@@ -1,0 +1,18 @@
+var exec = require('cordova/exec');
+
+/**
+ * Compatibility layer for apps that previously used cordova-plugin-iotum-badge.
+ * Routes calls through FirebasePlugin badge APIs.
+ */
+exports.set = function (count, callback, errorCallback) {
+    var normalized = Math.max(0, parseInt(count, 10) || 0);
+    exec(callback || null, errorCallback || null, 'FirebasePlugin', 'setBadgeNumber', [normalized]);
+};
+
+exports.clear = function (callback, errorCallback) {
+    exec(callback || null, errorCallback || null, 'FirebasePlugin', 'setBadgeNumber', [0]);
+};
+
+exports.get = function (callback, errorCallback) {
+    exec(callback, errorCallback || null, 'FirebasePlugin', 'getBadgeNumber', []);
+};


### PR DESCRIPTION
Adds real badge-count management on Android and iOS (previously no-op stubs), handles `badge_update` silent push payloads on both platforms, and ships a `cordova.plugins.iotumBadge` compatibility shim so apps migrating away from `cordova-plugin-iotum-badge` need zero call-site changes.

Fixes iotum/facetalk#11815
Fixes iotum/facetalk#11816.

---

## Changes

### Android

**`src/android/FirebasePlugin.java`**
- Added `BADGE_PREFS_NAME` / `BADGE_KEY` constants for a dedicated `SharedPreferences` store (`iotum_badge`).
- Added static helpers `persistBadgeNumber(Context, int)` and `getPersistedBadgeNumber(Context)` so the badge count can be written/read from both the plugin and the FCM receiver (which may run before the Cordova activity is alive).
- Wired `setBadgeNumber` and `getBadgeNumber` action strings to real implementations instead of the previous empty stubs.

**`src/android/CustomFCMReceiverPlugin.java`**
- Added a branch for `type == "badge_update"` silent push payloads.
- Extracts the `total` field and persists it via `FirebasePlugin.persistBadgeNumber()` so the count survives app restarts and is ready when the app next foregrounds.

### iOS

**`src/ios/FirebasePlugin.m`**
- Added `FirebaseBadgeMessageReceiver` — a `FirebasePluginMessageReceiver` subclass.
- Handles `badge_update` silent pushes by parsing the JSON `payload` field and calling `[[UIApplication sharedApplication] setApplicationIconBadgeNumber:]` on the main thread.
- Instantiated in `pluginInitialize` so it is registered for the full lifetime of the plugin.

### JavaScript / Cordova

**`www/iotumBadge.js`** *(new file)*
- Exposes `cordova.plugins.iotumBadge.set(count)`, `.clear()`, and `.get(callback)`, mirroring the API of the former `cordova-plugin-iotum-badge`.
- All calls delegate to `FirebasePlugin`'s `setBadgeNumber` / `getBadgeNumber` native actions.

**`plugin.xml`**
- Registers `www/iotumBadge.js` as the `IotumBadgeCompatibility` JS module, clobbering `cordova.plugins.iotumBadge`.

---

## Behaviour summary

| Trigger | Android | iOS |
|---|---|---|
| `setBadgeNumber(n)` JS call | Persists count in `SharedPreferences` | Sets `applicationIconBadgeNumber` |
| `getBadgeNumber()` JS call | Reads count from `SharedPreferences` | Returns `applicationIconBadgeNumber` |
| Silent push `{ type: "badge_update", total: n }` | Persists count without waking the app | Sets badge on main thread |
| `cordova.plugins.iotumBadge.set(n)` | Delegates to `setBadgeNumber` | Delegates to `setBadgeNumber` |
| `cordova.plugins.iotumBadge.clear()` | Delegates to `setBadgeNumber(0)` | Delegates to `setBadgeNumber(0)` |
| `cordova.plugins.iotumBadge.get(cb)` | Delegates to `getBadgeNumber` | Delegates to `getBadgeNumber` |